### PR TITLE
Bump acquisition-event-producer to 4.0.13

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -6,7 +6,7 @@ description := "Scala library to provide shared step-function models to Guardian
 
 libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.9" % "provided",
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.12",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.13",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
The latest version of acquisition-event-producer writes events to a kinesis stream - https://github.com/guardian/acquisition-event-producer/pull/41

Some apps get acquisition-event-producer transiently via support-models