### PR TITLE
Bump acquisition-event-producer to 4.0.15

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -6,7 +6,7 @@ description := "Scala library to provide shared step-function models to Guardian
 
 libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.9" % "provided",
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.14",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.15",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -92,7 +92,6 @@ object Fixtures {
           "componentId":null,
           "componentType":null,
           "source":null,
-          "abTest":null,
           "abTests":[{
             "name":"fakeTest",
             "variant":"fakeVariant"


### PR DESCRIPTION
This version removes the deprecated `abTest` field. https://github.com/guardian/acquisition-event-producer/pull/43