### PR TITLE
Add codecs to companion objects for state classes

### DIFF
--- a/support-models/src/main/scala/com/gu/support/encoding/CustomCodecs.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/CustomCodecs.scala
@@ -3,14 +3,12 @@ package com.gu.support.encoding
 import java.util.UUID
 
 import com.gu.i18n.{Country, CountryGroup, Currency}
-import com.gu.support.encoding.Codec._
-import com.gu.support.workers._
 import io.circe.{Decoder, Encoder}
 import org.joda.time.{DateTime, Days, LocalDate, Months}
 
 import scala.util.Try
 
-object CustomCodecs extends InternationalisationCodecs with ModelsCodecs with HelperCodecs
+object CustomCodecs extends InternationalisationCodecs with HelperCodecs
 
 trait InternationalisationCodecs {
   implicit val encodeCurrency: Encoder[Currency] = Encoder.encodeString.contramap[Currency](_.iso)
@@ -21,16 +19,6 @@ trait InternationalisationCodecs {
   implicit val encodeCountryAsAlpha2: Encoder[Country] = Encoder.encodeString.contramap[Country](_.alpha2)
   implicit val decodeCountry: Decoder[Country] =
     Decoder.decodeString.emap { code => CountryGroup.countryByCode(code).toRight(s"Unrecognised country code '$code'") }
-}
-
-trait ModelsCodecs {
-  self: InternationalisationCodecs with HelperCodecs =>
-
-  implicit val acquisitionDataCodec: Codec[AcquisitionData] = {
-    import com.gu.acquisition.instances.abTest._
-    deriveCodec
-  }
-
 }
 
 trait HelperCodecs {

--- a/support-models/src/main/scala/com/gu/support/promotions/ValidatedPromotion.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/ValidatedPromotion.scala
@@ -1,3 +1,10 @@
 package com.gu.support.promotions
 
 case class ValidatedPromotion(promoCode: PromoCode, promotion: Promotion)
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+object ValidatedPromotion {
+  implicit val decoder: Decoder[ValidatedPromotion] = deriveDecoder
+}

--- a/support-models/src/main/scala/com/gu/support/workers/AcquisitionData.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/AcquisitionData.scala
@@ -1,6 +1,8 @@
 package com.gu.support.workers
 
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
 import ophan.thrift.event.AbTest
 
 case class AcquisitionData(
@@ -8,3 +10,10 @@ case class AcquisitionData(
   referrerAcquisitionData: ReferrerAcquisitionData,
   supportAbTests: Set[AbTest]
 )
+
+object AcquisitionData {
+  implicit val acquisitionDataCodec: Codec[AcquisitionData] = {
+    import com.gu.acquisition.instances.abTest._
+    deriveCodec
+  }
+}

--- a/support-models/src/main/scala/com/gu/support/workers/ExecutionError.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ExecutionError.scala
@@ -1,3 +1,10 @@
 package com.gu.support.workers
 
 case class ExecutionError(Error: String, Cause: String)
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object ExecutionError {
+  implicit val codec: Codec[ExecutionError] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/JsonWrapper.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/JsonWrapper.scala
@@ -5,3 +5,10 @@ package com.gu.support.workers
  * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
  */
 case class JsonWrapper(state: String, error: Option[ExecutionError], requestInfo: RequestInfo)
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object JsonWrapper {
+  implicit val codec: Codec[JsonWrapper] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
@@ -3,3 +3,10 @@ package com.gu.support.workers
 case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String]){
   def appendMessage(message: String) = copy(messages = messages :+ message)
 }
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object RequestInfo {
+  implicit val codec: Codec[RequestInfo] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/SalesforceContactRecord.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/SalesforceContactRecord.scala
@@ -1,3 +1,10 @@
 package com.gu.support.workers
 
 case class SalesforceContactRecord(Id: String, AccountId: String)
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object SalesforceContactRecord {
+  implicit val codec: Codec[SalesforceContactRecord] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -1,6 +1,8 @@
 package com.gu.support.workers
 
 import com.gu.i18n.Country
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
 
 case class User(
   id: String,
@@ -14,3 +16,8 @@ case class User(
   allowGURelatedMail: Boolean = false,
   isTestUser: Boolean = false
 )
+
+object User {
+  import com.gu.support.encoding.CustomCodecs._
+  implicit val decoder: Codec[User] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/states/CheckoutFailureState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CheckoutFailureState.scala
@@ -1,8 +1,12 @@
 package com.gu.support.workers.states
 
-import com.gu.support.workers.User
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.workers.CheckoutFailureReasons.CheckoutFailureReason
+import com.gu.support.workers.User
 
 case class CheckoutFailureState(user: User, checkoutFailureReason: CheckoutFailureReason) extends StepFunctionUserState
 
-
+object CheckoutFailureState {
+  implicit val decoder: Codec[CheckoutFailureState] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -3,8 +3,7 @@ package com.gu.support.workers.states
 import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
-import com.gu.support.workers.User
-import com.gu.support.workers._
+import com.gu.support.workers.{User, _}
 
 case class CreatePaymentMethodState(
   requestId: UUID,
@@ -14,4 +13,11 @@ case class CreatePaymentMethodState(
   promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object CreatePaymentMethodState {
+  implicit val codec: Codec[CreatePaymentMethodState] = deriveCodec
+}
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
@@ -3,8 +3,7 @@ package com.gu.support.workers.states
 import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
-import com.gu.support.workers.{PaymentMethod, User}
-import com.gu.support.workers._
+import com.gu.support.workers.{PaymentMethod, User, _}
 
 case class CreateSalesforceContactState(
   requestId: UUID,
@@ -14,3 +13,10 @@ case class CreateSalesforceContactState(
   promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object CreateSalesforceContactState {
+  implicit val codec: Codec[CreateSalesforceContactState] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -3,8 +3,7 @@ package com.gu.support.workers.states
 import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
-import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User}
-import com.gu.support.workers._
+import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
@@ -15,3 +14,10 @@ case class CreateZuoraSubscriptionState(
   salesForceContact: SalesforceContactRecord,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object CreateZuoraSubscriptionState {
+  implicit val codec: Codec[CreateZuoraSubscriptionState] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/states/FailureHandlerState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/FailureHandlerState.scala
@@ -2,12 +2,18 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
-import com.gu.support.workers.User
-import com.gu.support.workers._
+import com.gu.support.workers.{User, _}
 
 case class FailureHandlerState(
   requestId: UUID,
   user: User,
   product: ProductType
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object FailureHandlerState {
+  implicit val codec: Codec[FailureHandlerState] = deriveCodec
+}
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.states
 
-import com.gu.support.workers.{PaymentMethod, User}
-import com.gu.support.workers._
+import com.gu.support.workers.{PaymentMethod, User, _}
 
 case class SendAcquisitionEventState(
   user: User,
@@ -9,3 +8,10 @@ case class SendAcquisitionEventState(
   paymentMethod: PaymentMethod,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object SendAcquisitionEventState {
+  implicit val codec: Codec[SendAcquisitionEventState] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -2,8 +2,7 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
-import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User}
-import com.gu.support.workers._
+import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -14,4 +13,11 @@ case class SendThankYouEmailState(
   accountNumber: String,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec._
+
+object SendThankYouEmailState {
+  implicit val codec: Codec[SendThankYouEmailState] = deriveCodec
+}
 


### PR DESCRIPTION
Defining Circe codecs in companion objects for case classes makes things much easier when using them from other projects. 

I missed these classes when I was refactoring this project previously so I'm adding them in now