### PR TITLE
Include subscription number in SendThankYouEmailState

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -11,6 +11,7 @@ case class SendThankYouEmailState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
+  subscriptionNumber: String,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -79,6 +79,7 @@ object SubscribeResponseAccount {
 }
 
 case class ZuoraAccountNumber(value: String)
+case class ZuoraSubscriptionNumber(value: String)
 
 case class SubscribeResponseAccount(
     accountNumber: String,
@@ -89,8 +90,8 @@ case class SubscribeResponseAccount(
     accountId: String,
     success: Boolean
 ) extends ZuoraResponse {
-
   def domainAccountNumber: ZuoraAccountNumber = ZuoraAccountNumber(accountNumber)
+  def domainSubscriptionNumber: ZuoraSubscriptionNumber = ZuoraSubscriptionNumber(subscriptionNumber)
 }
 
 object InvoiceResult {

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
@@ -17,7 +17,7 @@ object RatePlan {
 
 case class SubscriptionsResponse(subscriptions: List[Subscription])
 
-case class Subscription(accountNumber: String, status: String, ratePlans: List[RatePlan])
+case class Subscription(accountNumber: String, subscriptionNumber: String, status: String, ratePlans: List[RatePlan])
 
 case class RatePlan(productId: String, productName: String, productRatePlanId: String)
 

--- a/support-models/src/main/scala/com/gu/support/zuora/domain/package.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/domain/package.scala
@@ -1,17 +1,18 @@
 package com.gu.support.zuora
 
-import com.gu.support.zuora.api.response.{AccountRecord, RatePlan, Subscription, ZuoraAccountNumber}
+import com.gu.support.zuora.api.response._
 
 package object domain {
 
   case class ZuoraIsActive(value: Boolean) extends AnyVal
 
-  case class DomainSubscription(accountNumber: ZuoraAccountNumber, isActive: ZuoraIsActive, ratePlans: List[RatePlan])
+  case class DomainSubscription(accountNumber: ZuoraAccountNumber, subscriptionNumber: ZuoraSubscriptionNumber, isActive: ZuoraIsActive, ratePlans: List[RatePlan])
 
   object DomainSubscription {
     def fromSubscription(subscription: Subscription): DomainSubscription =
       DomainSubscription(
         ZuoraAccountNumber(subscription.accountNumber),
+        ZuoraSubscriptionNumber(subscription.subscriptionNumber),
         ZuoraIsActive(subscription.status == "Active"),
         subscription.ratePlans //this can be changed to map to a DomainRatePlan if necessary
       )

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -183,7 +183,8 @@ object Fixtures {
        |    "Id": "123",
        |    "AccountId": "123"
        |  },
-       |  "accountNumber": "123"
+       |  "accountNumber": "A-123",
+       |  "subscriptionNumber": "A-S123"
        |}
      """.stripMargin
 


### PR DESCRIPTION
We should be including this in the confirmation email see: https://github.com/guardian/support-workers/pull/167.