### PR TITLE
Upgrade sbt-release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 


### PR DESCRIPTION
The release process for support-internationalisation is currently not working.

This upgrade pulls in https://github.com/sbt/sbt-release/pull/215 to fix the issue.