### PR TITLE
Exclude integration tests from CI build and use released library versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This repo holds shared libraries used by [support-frontend](https://github.com/g
 ## [support-internationalisation](./support-internationalisation/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-internationalisation_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-internationalisation_2.12)
 
+## Tests
+
+`sbt test` - runs unit tests only and excludes integration tests.
+
+`sbt it:test` - runs all tests including integration tests (i.e. those which talk to real services e.g. AWS S3).
+
 ## Releasing
 ### Releasing to local repo
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,12 @@ val release = Seq[ReleaseStep](
   pushChanges
 )
 
+lazy val testSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
+  scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
+  javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
+  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"))
+)
+
 lazy val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.12.7",
@@ -48,26 +54,34 @@ lazy val commonSettings = Seq(
 
 lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.3.2",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "it, test"
 )
 
 lazy val supportModels = (project in file("support-models"))
+  .configs(IntegrationTest)
   .settings(
     commonSettings,
+    testSettings,
     libraryDependencies ++= commonDependencies
   )
 lazy val supportConfig = (project in file("support-config"))
+  .configs(IntegrationTest)
   .settings(
     commonSettings,
+    testSettings,
     libraryDependencies ++= commonDependencies
   )
 lazy val supportServices = (project in file("support-services"))
+  .configs(IntegrationTest)
   .settings(
     commonSettings,
+    testSettings,
     libraryDependencies ++= commonDependencies
   )
 lazy val supportInternationalisation = (project in file("support-internationalisation"))
+  .configs(IntegrationTest)
   .settings(
     commonSettings,
+    testSettings,
     libraryDependencies ++= commonDependencies
   )

--- a/support-services/build.sbt
+++ b/support-services/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
-  "com.gu" %% "support-internationalisation" % "0.9",
-  "com.gu" %% "support-models" % "0.45-SNAPSHOT",
+  "com.gu" %% "support-internationalisation" % "0.10",
+  "com.gu" %% "support-models" % "0.48",
   "com.gu" %% "support-config" % "0.17",
 )

--- a/support-services/src/test/java/com/gu/test/tags/annotations/IntegrationTest.java
+++ b/support-services/src/test/java/com/gu/test/tags/annotations/IntegrationTest.java
@@ -1,0 +1,14 @@
+package com.gu.test.tags.annotations;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface IntegrationTest {
+}

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceTest.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceTest.scala
@@ -3,8 +3,10 @@ package com.gu.support.catalog
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.support.config.Stages.PROD
 import com.gu.support.workers.{Annual, Monthly, Quarterly}
+import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.{FlatSpec, Matchers}
 
+@IntegrationTest
 class CatalogServiceTest extends FlatSpec with Matchers {
 
   "CatalogService" should "fetch the catalog from S3" in {


### PR DESCRIPTION
Whilst working on this project this week, I noticed that the build was broken. This was due to:

* Unreleased libraries specified in build.sbt
* CI attempting to run tests which talk to S3

This PR fixes those issues.