### PR TITLE
Add optional telephone number to User

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -15,7 +15,7 @@ case class User(
   allowThirdPartyMail: Boolean = false,
   allowGURelatedMail: Boolean = false,
   isTestUser: Boolean = false,
-  telphoneNumber: Option[String] = None
+  telephoneNumber: Option[String] = None
 )
 
 object User {

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -14,7 +14,8 @@ case class User(
   allowMembershipMail: Boolean = false,
   allowThirdPartyMail: Boolean = false,
   allowGURelatedMail: Boolean = false,
-  isTestUser: Boolean = false
+  isTestUser: Boolean = false,
+  telphoneNumber: Option[String] = None
 )
 
 object User {

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -11,11 +11,11 @@ case class User(
   lastName: String,
   country: Country,
   state: Option[String] = None,
+  telephoneNumber: Option[String] = None,
   allowMembershipMail: Boolean = false,
   allowThirdPartyMail: Boolean = false,
   allowGURelatedMail: Boolean = false,
-  isTestUser: Boolean = false,
-  telephoneNumber: Option[String] = None
+  isTestUser: Boolean = false
 )
 
 object User {


### PR DESCRIPTION
Our new digital pack checkout allows users to provide their telephone number. If they choose to provide it to us, we would like to make sure that information makes it to Salesforce. It will allow us to call the customer for e.g. retention purposes. 

To do that, this User model needs to have an optional telephone number.