### PR TITLE
Scale discounts correctly when the billing period is longer than the discount period

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/BillingPeriod.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/BillingPeriod.scala
@@ -5,6 +5,7 @@ import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 
 sealed trait BillingPeriod {
   val noun: String
+  val monthsInPeriod: Int
 }
 
 object BillingPeriod {
@@ -23,16 +24,20 @@ object BillingPeriod {
 
 case object Monthly extends BillingPeriod {
   override val noun = "month"
+  override val monthsInPeriod = 1
 }
 
 case object Quarterly extends BillingPeriod {
   override val noun = "quarter"
+  override val monthsInPeriod = 3
 }
 
 case object Annual extends BillingPeriod {
   override val noun = "year"
+  override val monthsInPeriod = 12
 }
 
 case object SixWeekly extends BillingPeriod {
   override val noun = "six weeks"
+  override val monthsInPeriod = 1
 }

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -1,6 +1,5 @@
 package com.gu.support.pricing
 
-import com.gu.i18n.Currency
 import com.gu.support.promotions._
 
 
@@ -14,6 +13,7 @@ case class PromotionSummary(
   description: String,
   promoCode: PromoCode,
   discountedPrice: Option[BigDecimal],
+  numberOfDiscountedPeriods: Option[Int],
   discount: Option[DiscountBenefit],
   freeTrialBenefit: Option[FreeTrialBenefit],
   incentive: Option[IncentiveBenefit] = None

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -5,7 +5,7 @@ import com.gu.support.catalog._
 import com.gu.support.pricing.PriceSummaryService.getDiscountedPrice
 import com.gu.support.promotions._
 import com.gu.support.touchpoint.TouchpointService
-import com.gu.support.workers.BillingPeriod
+import com.gu.support.workers.{BillingPeriod, Monthly}
 
 import scala.math.BigDecimal.RoundingMode
 
@@ -24,7 +24,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
         val priceSummaries = for {
           productRatePlan <- getSupportedRatePlansForCountryGroup(productRatePlans, countryGroup)
           price <- filterCurrencies(catalogService.getPriceList(productRatePlan).map(_.prices), countryGroup)
-        } yield getPriceSummary(maybePromoCode, countryGroup, productRatePlan.id, price)
+        } yield getPriceSummary(maybePromoCode, countryGroup, productRatePlan, price)
         (keys, priceSummaries.toMap)
     }
     nestPriceLists(grouped)
@@ -40,12 +40,12 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       .filter(price => countryGroup.supportedCurrencies.contains(price.currency))
 
 
-  private def getPriceSummary(maybePromoCode: Option[PromoCode], countryGroup: CountryGroup, productRatePlanId: ProductRatePlanId, price: Price) = {
+  private def getPriceSummary(maybePromoCode: Option[PromoCode], countryGroup: CountryGroup, productRatePlan: ProductRatePlan[Product], price: Price) = {
     val promotionSummary: Option[PromotionSummary] = for {
       promoCode <- maybePromoCode
       country <- countryGroup.defaultCountry.orElse(countryGroup.countries.headOption)
-      validPromotion <- promotionService.validatePromoCode(promoCode, country, productRatePlanId, isRenewal = false).toOption //Not dealing with renewals for now
-    } yield getPromotionSummary(validPromotion, price)
+      validPromotion <- promotionService.validatePromoCode(promoCode, country, productRatePlan.id, isRenewal = false).toOption //Not dealing with renewals for now
+    } yield getPromotionSummary(validPromotion, price, productRatePlan.billingPeriod)
 
     price.currency -> PriceSummary(
       price.value,
@@ -53,13 +53,13 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
     )
   }
 
-  private def getPromotionSummary(validatedPromotion: ValidatedPromotion, price: Price) = {
+  private def getPromotionSummary(validatedPromotion: ValidatedPromotion, price: Price, billingPeriod: BillingPeriod) = {
     import validatedPromotion._
     PromotionSummary(
       promotion.name,
       promotion.description,
       promoCode,
-      promotion.discount.map(getDiscountedPrice(price, _).value),
+      promotion.discount.map(getDiscountedPrice(price, _, billingPeriod).value),
       promotion.discount,
       promotion.freeTrial,
       promotion.incentive
@@ -85,9 +85,20 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
 }
 
 object PriceSummaryService {
-  def getDiscountedPrice(originalPrice: Price, discountBenefit: DiscountBenefit): Price = {
-    val multiplier = (100 - discountBenefit.amount) / 100
+  def getDiscountedPrice(originalPrice: Price, discountBenefit: DiscountBenefit, billingPeriod: BillingPeriod): Price = {
+    val scaledDiscount = getDiscountScaledToPeriod(discountBenefit, billingPeriod)
+    val multiplier = (100 - scaledDiscount) / 100
     val newPrice = originalPrice.value * multiplier
     originalPrice.copy(value = newPrice.setScale(2, RoundingMode.HALF_DOWN))
+  }
+
+  private def getDiscountScaledToPeriod(discountBenefit: DiscountBenefit, billingPeriod: BillingPeriod): Double = {
+    //If the discount period doesn't cover the whole of the billing period (often the case for annual billing)
+    //we need to work out the percentage of the period that is covered and adjust the discount accordingly
+    val percentageOfPeriodDiscounted = discountBenefit.durationMonths.fold(1.toDouble) { durationInMonths =>
+      Math.min(durationInMonths.getMonths.toDouble / billingPeriod.monthsInPeriod.toDouble, 1)
+    }
+    val newDiscountPercent = discountBenefit.amount * percentageOfPeriodDiscounted
+    BigDecimal(newDiscountPercent).setScale(2, RoundingMode.HALF_DOWN).toDouble
   }
 }

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -5,8 +5,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.support.catalog._
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.{DiscountBenefit, PromotionServiceSpec}
-import com.gu.support.config.TouchPointEnvironments.PROD
-import com.gu.support.workers.{Annual, Monthly, Quarterly}
+import com.gu.support.workers.{Annual, BillingPeriod, Monthly, Quarterly}
 import org.joda.time.Months
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -18,34 +17,48 @@ class PriceSummaryServiceSpec extends FlatSpec with Matchers {
 
     val paper = service.getPrices(Paper, Some("DISCOUNT_CODE"))
     paper(UK)(HomeDelivery)(Sixday)(Monthly)(GBP).price shouldBe 54.12
+    paper(UK)(HomeDelivery)(Sixday)(Monthly)(GBP).promotion.flatMap(_.discountedPrice) shouldBe Some(37.88)
+    paper(UK)(Collection)(EverydayPlus)(Monthly)(GBP).price shouldBe 51.96
+    paper(UK)(Collection)(EverydayPlus)(Monthly)(GBP).promotion.flatMap(_.discountedPrice) shouldBe Some(36.37)
 
     val guardianWeekly = service.getPrices(GuardianWeekly, Some("DISCOUNT_CODE"))
     guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).price shouldBe 37.50
-    guardianWeekly(UK)(Domestic)(NoProductOptions)(Annual)(GBP).promotion.flatMap(_.discountedPrice) shouldBe Some(105)
+    guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).promotion.flatMap(_.discountedPrice) shouldBe Some(26.25)
+    guardianWeekly(UK)(Domestic)(NoProductOptions)(Annual)(GBP).price shouldBe 150
+    guardianWeekly(UK)(Domestic)(NoProductOptions)(Annual)(GBP).promotion.flatMap(_.discountedPrice) shouldBe Some(138.75)
 
     val digitalPack = service.getPrices(DigitalPack, Some("DISCOUNT_CODE"))
-    val priceSummary = digitalPack(UK)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(GBP)
-    priceSummary.price shouldBe 11.99
-    priceSummary.promotion.get.discountedPrice shouldBe Some(8.39)
+    digitalPack(UK)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(GBP).price shouldBe 11.99
+    digitalPack(UK)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(GBP).promotion.get.discountedPrice shouldBe Some(8.39)
+    digitalPack(UK)(NoFulfilmentOptions)(NoProductOptions)(Annual)(GBP).price shouldBe 119.90
+    digitalPack(UK)(NoFulfilmentOptions)(NoProductOptions)(Annual)(GBP).promotion.get.discountedPrice shouldBe Some(110.91)
   }
 
   it should "work out a discount correctly" in {
-    val discountBenefit = DiscountBenefit(25, Some(Months.TWELVE))
+    val discountBenefit = DiscountBenefit(25, Some(Months.THREE))
     // TODO: It seems that Paper & Paper+ round discounts differently on the
     // current subscribe site. For instance Everyday and Sixday+ have the same
     // original price but different discounted values - £35.71 & £35.72.
     // We need to work out what they will actually get charged by Zuora
 
-    checkPrice(discountBenefit, 47.62, 35.71) //Everyday
-    checkPrice(discountBenefit, 51.96, 38.97) //Everyday+
-    checkPrice(discountBenefit, 41.12, 30.84) //Sixday
+    checkPrice(discountBenefit, 47.62, 35.71, Monthly) //Everyday
+    checkPrice(discountBenefit, 51.96, 38.97, Monthly) //Everyday+
+    checkPrice(discountBenefit, 41.12, 30.84, Monthly) //Sixday
     //checkPrice(discountBenefit, 47.62, 35.72) //Sixday+
-    checkPrice(discountBenefit, 20.76, 15.57) //Weekend
+    checkPrice(discountBenefit, 20.76, 15.57, Monthly) //Weekend
     //checkPrice(discountBenefit, 29.42, 22.07) //Weekend+
-    checkPrice(discountBenefit, 10.79, 8.09) //Sunday
+    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
     //checkPrice(discountBenefit, 22.06, 16.55) //Sunday+
+    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
+
+    //Digital Pack
+    checkPrice(discountBenefit, 11.99, 8.99, Monthly)
+    checkPrice(discountBenefit, 119.90, 112.41, Annual)
+
+    //Guardian Weekly domestic
+    checkPrice(DiscountBenefit(25, Some(Months.TWO)), 37.50, 31.25, Quarterly)
   }
 
-  def checkPrice(discount: DiscountBenefit, original: BigDecimal, expected: BigDecimal) =
-    PriceSummaryService.getDiscountedPrice(Price(original, GBP), discount).value shouldBe expected
+  def checkPrice(discount: DiscountBenefit, original: BigDecimal, expected: BigDecimal, billingPeriod: BillingPeriod) =
+    PriceSummaryService.getDiscountedPrice(Price(original, GBP), discount, billingPeriod).value shouldBe expected
 }

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -41,22 +41,25 @@ class PriceSummaryServiceSpec extends FlatSpec with Matchers {
     // original price but different discounted values - £35.71 & £35.72.
     // We need to work out what they will actually get charged by Zuora
 
-    checkPrice(discountBenefit, 47.62, 35.71, Monthly) //Everyday
-    checkPrice(discountBenefit, 51.96, 38.97, Monthly) //Everyday+
-    checkPrice(discountBenefit, 41.12, 30.84, Monthly) //Sixday
-    //checkPrice(discountBenefit, 47.62, 35.72) //Sixday+
-    checkPrice(discountBenefit, 20.76, 15.57, Monthly) //Weekend
-    //checkPrice(discountBenefit, 29.42, 22.07) //Weekend+
-    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
-    //checkPrice(discountBenefit, 22.06, 16.55) //Sunday+
-    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
-
-    //Digital Pack
-    checkPrice(discountBenefit, 11.99, 8.99, Monthly)
-    checkPrice(discountBenefit, 119.90, 112.41, Annual)
+//    checkPrice(discountBenefit, 47.62, 35.71, Monthly) //Everyday
+//    checkPrice(discountBenefit, 51.96, 38.97, Monthly) //Everyday+
+//    checkPrice(discountBenefit, 41.12, 30.84, Monthly) //Sixday
+//    //checkPrice(discountBenefit, 47.62, 35.72) //Sixday+
+//    checkPrice(discountBenefit, 20.76, 15.57, Monthly) //Weekend
+//    //checkPrice(discountBenefit, 29.42, 22.07) //Weekend+
+//    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
+//    //checkPrice(discountBenefit, 22.06, 16.55) //Sunday+
+//    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
+//
+//    //Digital Pack
+//    checkPrice(discountBenefit, 11.99, 8.99, Monthly)
+//    checkPrice(discountBenefit, 119.90, 112.41, Annual)
+    checkPrice(DiscountBenefit(25, Some(Months.FIVE)), 35.95, 28.46, Quarterly)
 
     //Guardian Weekly domestic
     checkPrice(DiscountBenefit(25, Some(Months.TWO)), 37.50, 31.25, Quarterly)
+
+
   }
 
   def checkPrice(discount: DiscountBenefit, original: BigDecimal, expected: BigDecimal, billingPeriod: BillingPeriod) =

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.support.catalog._
 import com.gu.support.encoding.CustomCodecs._
+import com.gu.support.pricing.PriceSummaryService.getNumberOfDiscountedPeriods
 import com.gu.support.promotions.{DiscountBenefit, PromotionServiceSpec}
 import com.gu.support.workers.{Annual, BillingPeriod, Monthly, Quarterly}
 import org.joda.time.Months
@@ -41,25 +42,47 @@ class PriceSummaryServiceSpec extends FlatSpec with Matchers {
     // original price but different discounted values - £35.71 & £35.72.
     // We need to work out what they will actually get charged by Zuora
 
-//    checkPrice(discountBenefit, 47.62, 35.71, Monthly) //Everyday
-//    checkPrice(discountBenefit, 51.96, 38.97, Monthly) //Everyday+
-//    checkPrice(discountBenefit, 41.12, 30.84, Monthly) //Sixday
-//    //checkPrice(discountBenefit, 47.62, 35.72) //Sixday+
-//    checkPrice(discountBenefit, 20.76, 15.57, Monthly) //Weekend
-//    //checkPrice(discountBenefit, 29.42, 22.07) //Weekend+
-//    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
-//    //checkPrice(discountBenefit, 22.06, 16.55) //Sunday+
-//    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
-//
-//    //Digital Pack
-//    checkPrice(discountBenefit, 11.99, 8.99, Monthly)
-//    checkPrice(discountBenefit, 119.90, 112.41, Annual)
+    checkPrice(discountBenefit, 47.62, 35.71, Monthly) //Everyday
+    checkPrice(discountBenefit, 51.96, 38.97, Monthly) //Everyday+
+    checkPrice(discountBenefit, 41.12, 30.84, Monthly) //Sixday
+    //checkPrice(discountBenefit, 47.62, 35.72) //Sixday+
+    checkPrice(discountBenefit, 20.76, 15.57, Monthly) //Weekend
+    //checkPrice(discountBenefit, 29.42, 22.07) //Weekend+
+    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
+    //checkPrice(discountBenefit, 22.06, 16.55) //Sunday+
+    checkPrice(discountBenefit, 10.79, 8.09, Monthly) //Sunday
+
+    //Digital Pack
+    checkPrice(discountBenefit, 11.99, 8.99, Monthly)
+    checkPrice(discountBenefit, 119.90, 112.41, Annual)
     checkPrice(DiscountBenefit(25, Some(Months.FIVE)), 35.95, 28.46, Quarterly)
 
     //Guardian Weekly domestic
     checkPrice(DiscountBenefit(25, Some(Months.TWO)), 37.50, 31.25, Quarterly)
 
 
+  }
+
+  it should "work out the number of discounted billing periods correctly" in {
+    getNumberOfDiscountedPeriods(Months.ONE, Monthly) shouldBe 1
+    getNumberOfDiscountedPeriods(Months.ONE, Quarterly) shouldBe 1
+    getNumberOfDiscountedPeriods(Months.ONE, Annual) shouldBe 1
+
+    getNumberOfDiscountedPeriods(Months.THREE, Monthly) shouldBe 3
+    getNumberOfDiscountedPeriods(Months.THREE, Quarterly) shouldBe 1
+    getNumberOfDiscountedPeriods(Months.THREE, Annual) shouldBe 1
+
+    getNumberOfDiscountedPeriods(Months.FOUR, Monthly) shouldBe 4
+    getNumberOfDiscountedPeriods(Months.FOUR, Quarterly) shouldBe 2
+    getNumberOfDiscountedPeriods(Months.FOUR, Annual) shouldBe 1
+
+    getNumberOfDiscountedPeriods(Months.TWELVE, Monthly) shouldBe 12
+    getNumberOfDiscountedPeriods(Months.TWELVE, Quarterly) shouldBe 4
+    getNumberOfDiscountedPeriods(Months.TWELVE, Annual) shouldBe 1
+
+    getNumberOfDiscountedPeriods(Months.months(13), Monthly) shouldBe 13
+    getNumberOfDiscountedPeriods(Months.months(13), Quarterly) shouldBe 5
+    getNumberOfDiscountedPeriods(Months.months(13), Annual) shouldBe 2
   }
 
   def checkPrice(discount: DiscountBenefit, original: BigDecimal, expected: BigDecimal, billingPeriod: BillingPeriod) =

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -19,8 +19,7 @@ object ServicesFixtures {
   val renewalPromoCode = "RENEWAL_CODE"
   val trackingPromoCode = "TRACKING_CODE"
 
-  val validProductRatePlanIds = DigitalPack.ratePlans(PROD).map(_.id) ++
-    GuardianWeekly.getProductRatePlan(PROD, Annual, Domestic, NoProductOptions).map(prp => List(prp.id)).getOrElse(Nil)
+  val validProductRatePlanIds = Product.allProducts.flatMap(_.ratePlans(PROD).map(_.id))
   val validProductRatePlanId = validProductRatePlanIds.head
   val invalidProductRatePlanId = "67890"
 


### PR DESCRIPTION
When applying a discount promotion, if the discount period doesn't cover the whole of the billing period (often the case for annual billing) then we can't just apply the discount to the price directly, we need to work out the percentage of the period that is covered and adjust the discount accordingly.
