### PR TITLE
Deduplicate the credentials providers in support-services

### DIFF
--- a/support-services/src/main/scala/com/gu/aws/aws.scala
+++ b/support-services/src/main/scala/com/gu/aws/aws.scala
@@ -1,0 +1,15 @@
+package com.gu
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider}
+
+package object aws {
+  val ProfileName = "membership"
+
+  lazy val CredentialsProvider = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider(ProfileName),
+    new InstanceProfileCredentialsProvider(false),
+    new EnvironmentVariableCredentialsProvider()
+  )
+
+}

--- a/support-services/src/main/scala/com/gu/support/catalog/AwsS3Client.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/AwsS3Client.scala
@@ -1,7 +1,6 @@
 package com.gu.support.catalog
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.gu.aws.CredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.model.{GetObjectRequest, S3ObjectInputStream}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
@@ -13,12 +12,6 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 object AwsS3Client extends LazyLogging{
-  val ProfileName = "membership"
-
-  lazy val CredentialsProvider = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider(ProfileName),
-    new InstanceProfileCredentialsProvider(false)
-  )
 
   implicit val s3: AmazonS3 =
     AmazonS3ClientBuilder

--- a/support-services/src/main/scala/com/gu/support/promotions/dynamo/DynamoTables.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/dynamo/DynamoTables.scala
@@ -1,19 +1,11 @@
 package com.gu.support.promotions.dynamo
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.gu.aws.CredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.document.{DynamoDB, Table}
 
 object DynamoTables {
-
-  val ProfileName = "membership"
-
-  lazy val CredentialsProvider = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider(ProfileName),
-    new InstanceProfileCredentialsProvider(false)
-  )
 
   def getTable[T](table: String): Table = {
     val dynamoDBClient = AmazonDynamoDBClient.builder


### PR DESCRIPTION
We have previously had 2 separate credentials providers in this project, neither of which actually work in lambdas (oops!). This fixes that.