### PR TITLE
Add address fields to direct debit payment method

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -36,6 +36,11 @@ case class DirectDebitPaymentMethod(
   bankCode: String,
   bankTransferAccountNumber: String,
   country: Country = Country.UK,
+  city: String,
+  postalCode: String,
+  state: String,
+  streetName: String,
+  streetNumber: String,
   bankTransferType: String = "DirectDebitUK",
   `type`: String = "BankTransfer"
 ) extends PaymentMethod

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -39,9 +39,9 @@ case class DirectDebitPaymentMethod(
   country: Country = Country.UK,
   city: String,
   postalCode: String,
-  state: String,
+  state: Option[String],
   streetName: String,
-  streetNumber: String,
+  streetNumber: Option[String],
   bankTransferType: String = "DirectDebitUK",
   `type`: String = "BankTransfer"
 ) extends PaymentMethod

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -29,7 +29,6 @@ case class PayPalReferenceTransaction(
   `type`: String = "PayPal"
 ) extends PaymentMethod
 
-
 case class DirectDebitPaymentMethod(
   firstName: String,
   lastName: String,
@@ -37,10 +36,10 @@ case class DirectDebitPaymentMethod(
   bankCode: String,
   bankTransferAccountNumber: String,
   country: Country = Country.UK,
-  city: String,
-  postalCode: String,
+  city: Option[String],
+  postalCode: Option[String],
   state: Option[String],
-  streetName: String,
+  streetName: Option[String],
   streetNumber: Option[String],
   bankTransferType: String = "DirectDebitUK",
   `type`: String = "BankTransfer"

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -29,6 +29,7 @@ case class PayPalReferenceTransaction(
   `type`: String = "PayPal"
 ) extends PaymentMethod
 
+
 case class DirectDebitPaymentMethod(
   firstName: String,
   lastName: String,
@@ -36,6 +37,11 @@ case class DirectDebitPaymentMethod(
   bankCode: String,
   bankTransferAccountNumber: String,
   country: Country = Country.UK,
+  city: String,
+  postalCode: String,
+  state: String,
+  streetName: String,
+  streetNumber: String,
   bankTransferType: String = "DirectDebitUK",
   `type`: String = "BankTransfer"
 ) extends PaymentMethod

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -119,7 +119,17 @@ object Fixtures {
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", "test@gu.com", Country.UK)
   val creditCardPaymentMethod = CreditCardReferenceTransaction(tokenId, secondTokenId, cardNumber, Some(Country.UK), 12, 22, "AmericanExpress")
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
-  val directDebitPaymentMethod = DirectDebitPaymentMethod("Barry", "Humphreys", "Barry Humphreys", "200000", "55779911")
+  val directDebitPaymentMethod = DirectDebitPaymentMethod(
+    firstName = "Barry",
+    lastName = "Humphreys",
+    bankTransferAccountName = "Barry Humphreys",
+    bankCode = "200000", bankTransferAccountNumber = "55779911",
+    city = Some("London"),
+    postalCode = Some("abc 123"),
+    state = None,
+    streetName = Some("easy street"),
+    streetNumber = None
+  )
   val productRatePlanId = "12345"
   val productRatePlanChargeId = "67890"
 


### PR DESCRIPTION
We need to send address information when a new direct debit mandate is created via GoCardless. 

The call made to create a Zuora subscription sends payment method info, and the Zuora-GoCardless integration uses that info to set up the mandate (and thus sends the address fields).

The new fields are currently optional since the contributions flow won't be sending them. 

Documentation for the subscribe request (including what payment method fields can be sent) is here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
