### PR TITLE
Fix free trial promotions

### DIFF
--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
@@ -29,7 +29,7 @@ class FreeTrialApplicator(freeTrial: FreeTrialBenefit) extends BenefitApplicator
     val subscription = subscriptionData.subscription
     subscriptionData.copy(
       subscription = subscription.copy(
-        contractEffectiveDate = subscription.contractEffectiveDate.plusDays(freeTrial.duration.getDays)
+        contractAcceptanceDate = subscription.contractAcceptanceDate.plusDays(freeTrial.duration.getDays)
       )
     )
   }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionApplicatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionApplicatorSpec.scala
@@ -20,7 +20,7 @@ class PromotionApplicatorSpec extends FlatSpec with Matchers {
     val result = PromotionApplicator(validFreeTrial, config)
       .applyTo(subscriptionData)
 
-    result.subscription.contractEffectiveDate shouldBe correctDate
+    result.subscription.contractAcceptanceDate shouldBe correctDate
     result.subscription.promoCode shouldBe Some(freeTrialPromoCode)
   }
 
@@ -28,7 +28,7 @@ class PromotionApplicatorSpec extends FlatSpec with Matchers {
     val result = PromotionApplicator(validDouble, config)
       .applyTo(subscriptionData)
 
-    result.subscription.contractEffectiveDate shouldBe correctDate
+    result.subscription.contractAcceptanceDate shouldBe correctDate
     result.subscription.promoCode shouldBe Some(doublePromoCode)
     result.ratePlanData.length shouldBe 2
   }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -31,13 +31,13 @@ class PromotionServiceSpec extends FlatSpec with Matchers {
 
   it should "apply a FreeTrial PromoCode" in {
     val result = serviceWithFixtures.applyPromotion(freeTrialPromoCode, UK, validProductRatePlanId, subscriptionData, false)
-    result.subscription.contractEffectiveDate shouldBe subscriptionData.subscription.contractEffectiveDate.plusDays(freeTrialBenefit.get.duration.getDays)
+    result.subscription.contractAcceptanceDate shouldBe subscriptionData.subscription.contractAcceptanceDate.plusDays(freeTrialBenefit.get.duration.getDays)
     result.subscription.promoCode shouldBe Some(freeTrialPromoCode)
   }
 
   it should "apply a double PromoCode" in {
     val result = serviceWithFixtures.applyPromotion(doublePromoCode, UK, validProductRatePlanId, subscriptionData, false)
-    result.subscription.contractEffectiveDate shouldBe subscriptionData.subscription.contractEffectiveDate.plusDays(freeTrialBenefit.get.duration.getDays)
+    result.subscription.contractAcceptanceDate shouldBe subscriptionData.subscription.contractAcceptanceDate.plusDays(freeTrialBenefit.get.duration.getDays)
     result.ratePlanData.length shouldBe 2
     result.subscription.promoCode shouldBe Some(doublePromoCode)
   }


### PR DESCRIPTION
Free trial promotions should amend the `contractAcceptanceDate` not `contractEffectiveDate`

Fixes [this bug](https://trello.com/c/IvD3rSew/2200-investigate-bug-with-free-trial-promotions)