### PR TITLE
Add optional address fields to PaymentFields also

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -15,7 +15,12 @@ case class StripePaymentFields(stripeToken: String) extends PaymentFields
 case class DirectDebitPaymentFields(
   accountHolderName: String,
   sortCode: String,
-  accountNumber: String
+  accountNumber: String,
+  city: Option[String],
+  postalCode: Option[String],
+  state: Option[String],
+  streetName: Option[String],
+  streetNumber: Option[String],
 ) extends PaymentFields
 
 object PaymentFields {


### PR DESCRIPTION
We need to send address information when a new direct debit mandate is created via GoCardless.

The call made to create a Zuora subscription sends payment method info, and the Zuora-GoCardless integration uses that info to set up the mandate (and thus sends the address fields).

https://github.com/guardian/support-libraries/pull/20 added these optional address fields to PaymentMethod (so that Zuora can send them to GoCardless, but we will receive the address fields as PaymentFields so I should add the address fields there too (see: https://github.com/guardian/support-frontend/blob/master/app/services/stepfunctions/SupportWorkersClient.scala#L101)