### PR TITLE
Add billing address to user.

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/Address.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Address.scala
@@ -1,0 +1,21 @@
+package com.gu.support.workers
+
+import com.gu.i18n.Country
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
+
+case class Address(
+  lineOne: Option[String],
+  lineTwo: Option[String],
+  city: Option[String],
+  state: Option[String],
+  postCode: Option[String],
+  country: Country
+)
+
+object Address {
+  implicit val AddressCodec: Codec[Address] = {
+    import com.gu.support.encoding.CustomCodecs._
+    deriveCodec
+  }
+}

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -11,6 +11,7 @@ case class User(
   lastName: String,
   country: Country,
   state: Option[String] = None,
+  billingAddress: Option[Address],
   telephoneNumber: Option[String] = None,
   allowMembershipMail: Boolean = false,
   allowThirdPartyMail: Boolean = false,


### PR DESCRIPTION
We previously didn't collect address details other than country and now we need to 
1) provide them to GoCardless when a mandate is created (for digital pack and any future checkout flows)
2) send them to the Salesforce billing address so that CSRs will have access to these details to e.g. verify identity 

To implement 1) we collected address details in the digital pack checkout form and did some munging in `support-frontend` before sending the details along to `support-workers`

Since we now have to do more with addresses, and we will only need to do more with addresses in future checkouts (and I think it makes more sense for `support-workers` to care about what daa Zuora or Salesforce needs than `support-frontend`) I'm going to 
a) add a billing address to `User`
b) start sending billing address from `support-frontend`
c) get `support-workers` to munge the address based on billlingAddress that's on `User` into a zuora-friendly format instead of `support-frontend`, and continue to send it in the zuora subscribe request. Then also send billing address to salesforce, if there is one (recurring contributions still won't have one).
d) get `support-frontend` to stop sending address-related `PaymentField`s, and remove the zuora-friendly field munging code that's now in `support-workers`
e) come back here to `support-libraries` to remove address related fields from `DirectDebitPaymentMethod`
