### PR TITLE
Make billing address required.

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -11,7 +11,7 @@ case class User(
   lastName: String,
   country: Country,
   state: Option[String] = None,
-  billingAddress: Option[Address],
+  billingAddress: Address,
   telephoneNumber: Option[String] = None,
   allowMembershipMail: Boolean = false,
   allowThirdPartyMail: Boolean = false,

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -15,6 +15,9 @@ object Fixtures {
           "firstName": "test",
           "lastName": "user",
           "country": "GB",
+          "billingAddress": {
+            "country": "GB"
+          },
           "allowMembershipMail": false,
           "allowThirdPartyMail": false,
           "allowGURelatedMail": false,


### PR DESCRIPTION
When I added billing address to user here https://github.com/guardian/support-libraries/pull/23

I made it optional. But support-frontend always sends it since country is required: https://github.com/guardian/support-frontend/pull/1514/files#diff-387d7b8a4dbe5c745f521533ef152395R153

Ooops.