### PR TITLE
remove unused fields in support-models

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -15,12 +15,7 @@ case class StripePaymentFields(stripeToken: String) extends PaymentFields
 case class DirectDebitPaymentFields(
   accountHolderName: String,
   sortCode: String,
-  accountNumber: String,
-  city: Option[String],
-  postalCode: Option[String],
-  state: Option[String],
-  streetName: Option[String],
-  streetNumber: Option[String],
+  accountNumber: String
 ) extends PaymentFields
 
 object PaymentFields {

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -9,8 +9,6 @@ case class User(
   primaryEmailAddress: String,
   firstName: String,
   lastName: String,
-  country: Country,
-  state: Option[String] = None,
   billingAddress: Address,
   telephoneNumber: Option[String] = None,
   allowMembershipMail: Boolean = false,


### PR DESCRIPTION
Now that `User` has a billing address that contains address fields and `support-workers` will read those fields from the billing address instead, we can remove them.

`support-workers` will also no longer read address details off payment fields, and https://github.com/guardian/support-frontend/pull/1520 will stop sending them from `support-frontend`, so these can also be removed.

So,  once https://github.com/guardian/support-frontend/pull/1520 and https://github.com/guardian/support-workers/pull/176 are live
- This change to `support-models` can be released
- I will raise a version bump PR in `support-workers` first because that code can stop requiring these fields, and it doesn't matter if `support-frontend` keeps sending them
- I will raise a version bump PR in `support-frontend` next to stop sending the fields removed here 