### PR TITLE
Stop keeping ratePlanId for digipack in Zuora config

### DIFF
--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -38,11 +38,6 @@ touchpoint.backend.environments {
       digitalpack {
         defaultFreeTrialPeriodDays = 14
         paymentGracePeriod = 2
-        productRatePlanIds {
-          monthly = "2c92a0fb4edd70c8014edeaa4eae220a"
-          quarterly = "2c92a0fb4edd70c8014edeaa4e8521fe"
-          annual = "2c92a0fb4edd70c8014edeaa4e972204"
-        }
       }
     }
     promotions {

--- a/support-config/src/main/resources/touchpoint.SANDBOX.conf
+++ b/support-config/src/main/resources/touchpoint.SANDBOX.conf
@@ -43,11 +43,6 @@ touchpoint.backend.environments {
       digitalpack = {
         defaultFreeTrialPeriodDays = 14
         paymentGracePeriod = 2
-        productRatePlanIds {
-          monthly = "2c92c0f84bbfec8b014bc655f4852d9d"
-          quarterly = "2c92c0f84bbfec58014bc6a2d43a1f5b"
-          annual = "2c92c0f94bbffaaa014bc6a4212e205b"
-        }
       }
     }
     promotions {

--- a/support-config/src/main/resources/touchpoint.UAT.conf
+++ b/support-config/src/main/resources/touchpoint.UAT.conf
@@ -38,11 +38,6 @@ touchpoint.backend.environments {
       digitalpack {
         defaultFreeTrialPeriodDays = 14
         paymentGracePeriod = 2
-        productRatePlanIds {
-          monthly = "2c92c0f94f2acf73014f2c908f671591"
-          quarterly = "2c92c0f94f2acf76014f2c92b5791f0f"
-          annual = "2c92c0f84f2ac59d014f2c94aea9199e"
-        }
       }
 
     }

--- a/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
@@ -7,9 +7,7 @@ import com.typesafe.config.Config
 
 case class ZuoraContributionConfig(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
 
-case class ZuoraDigitalPackConfig(defaultFreeTrialPeriod: Int, paymentGracePeriod: Int, productRatePlans: ProductRatePlans)
-
-case class ProductRatePlans(monthly: ProductRatePlanId, quarterly: ProductRatePlanId, annual: ProductRatePlanId)
+case class ZuoraDigitalPackConfig(defaultFreeTrialPeriod: Int, paymentGracePeriod: Int)
 
 case class ZuoraConfig(
   url: String,
@@ -25,12 +23,6 @@ case class ZuoraConfig(
       case Annual => annualContribution
       case _ => monthlyContribution
     }
-
-  def digitalPackRatePlan(billingPeriod: BillingPeriod): ProductRatePlanId = billingPeriod match {
-    case Annual => digitalPack.productRatePlans.annual
-    case Quarterly => digitalPack.productRatePlans.quarterly
-    case Monthly => digitalPack.productRatePlans.monthly
-  }
 }
 
 class ZuoraConfigProvider(config: Config, defaultStage: Stage) extends TouchpointConfigProvider[ZuoraConfig](config, defaultStage) {
@@ -51,11 +43,6 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage) extends Touchpoin
 
   private def digitalPackFromConfig(config: Config) = ZuoraDigitalPackConfig(
     defaultFreeTrialPeriod = config.getInt("defaultFreeTrialPeriodDays"),
-    paymentGracePeriod = config.getInt("paymentGracePeriod"),
-    productRatePlans = ProductRatePlans(
-      monthly = config.getString("productRatePlanIds.monthly"),
-      quarterly = config.getString("productRatePlanIds.quarterly"),
-      annual = config.getString("productRatePlanIds.annual")
-    )
+    paymentGracePeriod = config.getInt("paymentGracePeriod")
   )
 }


### PR DESCRIPTION
Once https://github.com/guardian/support-workers/pull/180 is merged, we will stop fetching ratePlanIds for digital packs from the ZuoraConfig. So, let's remove `ProductRatePlanId`s from the config as they're no longer used. 

And then let's be pleased that we're keeping track of `ProductRatePlanId`s for digital pack in one place instead of two 🎉 

I did a search within support-workers to see that I'd replaced all the usages, and also:

![image](https://user-images.githubusercontent.com/3072877/53185000-0a25ff00-35f6-11e9-90ef-a82a478089a8.png)
