### PR TITLE
Add paper to ProductType

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -6,6 +6,8 @@ import com.gu.support.encoding.Codec.deriveCodec
 import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
 import cats.syntax.functor._
+import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.{FulfilmentOptions, ProductOptions}
 
 
 sealed trait ProductType {
@@ -31,19 +33,31 @@ case class DigitalPack(
   override def describe: String = s"$billingPeriod-DigitalPack-$currency"
 }
 
+case class Paper(
+  currency: Currency = GBP,
+  billingPeriod: BillingPeriod = Monthly,
+  fulfilmentOptions: FulfilmentOptions,
+  productOptions: ProductOptions
+) extends ProductType {
+  override def describe: String = s"$Paper-$fulfilmentOptions-$productOptions"
+}
+
 object ProductType {
   import com.gu.support.encoding.CustomCodecs._
   implicit val codecDigitalPack: Codec[DigitalPack] = deriveCodec
   implicit val codecContribution: Codec[Contribution] = deriveCodec
+  implicit val codecPaper: Codec[Paper] = deriveCodec
 
   implicit val encodeProduct: Encoder[ProductType] = Encoder.instance {
     case d: DigitalPack => d.asJson
     case c: Contribution => c.asJson
+    case p: Paper => p.asJson
   }
 
   implicit val decodeProduct: Decoder[ProductType] =
     List[Decoder[ProductType]](
       Decoder[Contribution].widen,
-      Decoder[DigitalPack].widen
+      Decoder[DigitalPack].widen,
+      Decoder[Paper].widen
     ).reduceLeft(_ or _)
 }


### PR DESCRIPTION
`ProductType` will be sent by `support-frontend` to `support-workers` when creating a print subscription. 