### PR TITLE
Bump acquisition-event-producer-play26 version to 4.0.18

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -6,7 +6,7 @@ description := "Scala library to provide shared step-function models to Guardian
 
 libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.12",
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.16",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.18",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
 ...to include SwG PaymentProvider

This is to allow payment-api to set `Acquisition` data to `paymentProvider=ophan.thrift.event.PaymentProvider.SubscribeWithGoogle`